### PR TITLE
pytz 2025.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,13 +23,18 @@ requirements:
     - python
 
 test:
+  source_files:
+    - pytz/tests
+    - README.rst  # Required for some documentation tests
   imports:
     - pytz
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv pytz/tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://pythonhosted.org/pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytz" %}
-{% set version = "2024.1" %}
+{% set version = "2025.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytz-{{ version }}.tar.gz
-  sha256: 2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812
+  sha256: 360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
@@ -27,11 +27,12 @@ test:
     - pytz
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
 
 about:
-  home: https://pythonhosted.org/pytz/
+  home: https://pythonhosted.org/pytz
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
@@ -42,7 +43,7 @@ about:
     accurate and cross platform timezone calculations using Python 2.4 or
     higher. It also solves the issue of ambiguous times at the end of daylight
     saving time.
-  doc_url: https://pythonhosted.org/pytz/
+  doc_url: https://pythonhosted.org/pytz
   dev_url: https://github.com/stub42/pytz
 
 extra:


### PR DESCRIPTION
pytz 2025.2 

**Destination channel:** Defaults

### Links

- [PKG-8382]
- dev_url:        https://github.com/stub42/pytz/tree/release_2025.2
- conda_forge:    https://github.com/conda-forge/pytz-feedstock
- pypi:           https://pypi.org/project/pytz/2025.2
- pypi inspector: https://inspector.pypi.io/project/pytz/2025.2

### Explanation of changes:

- new version number


[PKG-8382]: https://anaconda.atlassian.net/browse/PKG-8382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ