### PR TITLE
Update version to 2026.1.post1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytz" %}
-{% set version = "2025.2" %}
+{% set version = "2026.1.post1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytz-{{ version }}.tar.gz
-  sha256: 360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3
+  sha256: 3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv


### PR DESCRIPTION
pytz 2026.1.post1

**Destination channel:** defaults

### Links

- [PKG-12818](https://anaconda.atlassian.net/browse/PKG-12818) 
- [Upstream repository](https://github.com/stub42/pytz)

### Explanation of changes:
- New version number


[PKG-12818]: https://anaconda.atlassian.net/browse/PKG-12818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ